### PR TITLE
Moving console to console widget

### DIFF
--- a/consolewidget.cpp
+++ b/consolewidget.cpp
@@ -1,25 +1,37 @@
 #include "consolewidget.h"
-#include <QtWidgets>
+
+// #include <Python.h> 
+//#include <python3.8/Python.h> can use this notation to chose specific versions of python if got wide imports.
+// #include <QDebug>
 
 /**
  * @brief Construct a new Console Widget:: Console Widget object
  * 
  * @param parent 
  */
-ConsoleWidget::ConsoleWidget(QWidget *parent) : QWidget(parent)
+ConsoleWidget::ConsoleWidget(QWidget *parent) : QWidget(parent), console(new pyConsole())
 {
+    QPushButton* button = new QPushButton(tr("Run"));
+    
+    lineEdit = new QLineEdit();
+    lineEdit->setAcceptDrops(true);
+    lineEdit->setPlaceholderText("Enter Python Commands in here.");
+    
+    textEdit = new QPlainTextEdit();
+    textEdit->setPlaceholderText("Outputs Display Here.");
+    textEdit->setReadOnly(true);
+    textEdit->setMaximumBlockCount(100);
 
-    QPushButton *button = new QPushButton(tr("Run"));
-    QLineEdit *lineEdit = new QLineEdit();
-    QTextEdit *textEdit = new QTextEdit();
-    QVBoxLayout *layout  = new QVBoxLayout(this);
+    QVBoxLayout *vbox = new QVBoxLayout;
+    vbox->addWidget(lineEdit);
+    vbox->addWidget(button);
+    vbox->addWidget(textEdit);
+    
+    //Connect Button Push to the Update Console function. 
+    QObject::connect(button, &QPushButton::clicked, this, &ConsoleWidget::updateConsole , Qt::QueuedConnection);
+    QObject::connect(lineEdit, &QLineEdit::returnPressed, this, &ConsoleWidget::updateConsole , Qt::QueuedConnection);
+    this->setLayout(vbox);
 
-    layout->addWidget(lineEdit);
-    layout->addWidget(button);
-    layout->addWidget(textEdit);
-
-    this->setLayout(layout);
-    this->show();
 }
 
 /**
@@ -28,5 +40,40 @@ ConsoleWidget::ConsoleWidget(QWidget *parent) : QWidget(parent)
  */
 ConsoleWidget::~ConsoleWidget()
 {
+    console->~pyConsole();
+}
 
+/**
+ * @brief Called when Button Pressed contains logic that takes text passes to Python and displays output. 
+ * 
+ */
+void ConsoleWidget::updateConsole(){
+    bool debug = false;
+    
+    if (debug)
+    {
+        qInfo() << "Start of Update Console";    
+    }
+
+    //Test1
+    //lineEdit->setText("Test");
+    //Test2
+    /* 
+    QString linetext = lineEdit->text();
+    QString text = textEdit->toPlainText();
+    textEdit->setText(text +linetext); 
+    */
+        
+    textEdit->appendPlainText(">>>" + lineEdit->text());
+    QString output = console->pyRun(lineEdit->text());
+    if (output!="")
+    {
+        textEdit->appendPlainText(output);
+    }
+    lineEdit->setText("");
+    
+    if (debug)
+    {
+        qInfo() << "End of Update Console";
+    }
 }

--- a/consolewidget.cpp
+++ b/consolewidget.cpp
@@ -1,6 +1,11 @@
 #include "consolewidget.h"
 #include <QtWidgets>
 
+/**
+ * @brief Construct a new Console Widget:: Console Widget object
+ * 
+ * @param parent 
+ */
 ConsoleWidget::ConsoleWidget(QWidget *parent) : QWidget(parent)
 {
 
@@ -15,4 +20,13 @@ ConsoleWidget::ConsoleWidget(QWidget *parent) : QWidget(parent)
 
     this->setLayout(layout);
     this->show();
+}
+
+/**
+ * @brief Destroy the Console Widget:: Console Widget object
+ * 
+ */
+ConsoleWidget::~ConsoleWidget()
+{
+
 }

--- a/consolewidget.h
+++ b/consolewidget.h
@@ -3,12 +3,13 @@
 
 #include <QWidget>
 
+
 class ConsoleWidget : public QWidget
 {
     Q_OBJECT
 public:
     explicit ConsoleWidget(QWidget *parent = nullptr);
-
+    ~ConsoleWidget();
 Q_SIGNALS:
 
 };

--- a/consolewidget.h
+++ b/consolewidget.h
@@ -2,7 +2,8 @@
 #define CONSOLEWIDGET_H
 
 #include <QWidget>
-
+#include <QtWidgets>
+#include "pyConsole.h" 
 
 class ConsoleWidget : public QWidget
 {
@@ -12,6 +13,13 @@ public:
     ~ConsoleWidget();
 Q_SIGNALS:
 
+private Q_SLOTS:
+    void updateConsole();
+
+private:
+    pyConsole* console;
+    QLineEdit* lineEdit;
+    QPlainTextEdit* textEdit;
 };
 
 #endif // CONSOLEWIDGET_H

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1,19 +1,13 @@
-#include <Python.h> 
-#include <QtWidgets>
-#include <QDebug>
 #include "mainwindow.h"
-//#include <python3.8/Python.h> can use this notation to chose specific versions of python if got wide imports.
 
 /**
  * @brief Construct a new Main Window:: Main Window object
  * 
  * @param parent 
  */
-MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) //, consoleWidget(new ConsoleWidget())
+MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) , consoleWidget(new ConsoleWidget())
 {
-    consoleWidget = new ConsoleWidget(this);
-    //consoleWidget->show();
-    console = new pyConsole(); 
+    
     QTextEdit* textEdit = new QTextEdit(this);
     this->setCentralWidget(textEdit);
     this->createDockWindows();
@@ -27,7 +21,6 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) //, consoleWidget(
  */
 MainWindow::~MainWindow()
 {
-    console->~pyConsole();
 }
 
 /**
@@ -35,73 +28,10 @@ MainWindow::~MainWindow()
  * 
  */
 void MainWindow::createDockWindows(){
-
-    dock= new QDockWidget(tr("Python Console Test"), this);
+    dock= new QDockWidget(tr("Python Console"), this);
     dock->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea | Qt::BottomDockWidgetArea);
-    
-    box = new QGroupBox(dock);
-    
-    button = new QPushButton(tr("Run"));
-    
-    lineEdit = new QLineEdit();
-    lineEdit->setAcceptDrops(true);
-    lineEdit->setPlaceholderText("Enter Python Commands in here.");
-    
-    textEdit = new QPlainTextEdit();
-    textEdit->setPlaceholderText("Outputs Display Here.");
-    textEdit->setReadOnly(true);
-    textEdit->setMaximumBlockCount(100);
-
-    QVBoxLayout *vbox = new QVBoxLayout;
-    vbox->addWidget(lineEdit);
-    vbox->addWidget(button);
-    vbox->addWidget(textEdit);
-    //vbox->addStretch(1);
-    
-    box->setContentsMargins(0,0,0,0);
-    box->setLayout(vbox);
-
-    dock->setWidget(box);
+    dock->setWidget(consoleWidget);
     this->addDockWidget(Qt::BottomDockWidgetArea, dock);
 
-     dock= new QDockWidget(tr("Test"), this);    
-    dock->setWidget(consoleWidget);
-    this->addDockWidget(Qt::LeftDockWidgetArea, dock);
-    //Connect Button Push to the Update Console function. 
-    QObject::connect(button, &QPushButton::clicked, this, &MainWindow::updateConsole , Qt::QueuedConnection);
 }
 
-/**
- * @brief Called when Button Pressed contains logic that takes text passes to Python and displays output. 
- * 
- */
-void MainWindow::updateConsole(){
-    bool debug = false;
-    
-    if (debug)
-    {
-        qInfo() << "Start of Update Console";    
-    }
-
-    //Test1
-    //lineEdit->setText("Test");
-    //Test2
-    /* 
-    QString linetext = lineEdit->text();
-    QString text = textEdit->toPlainText();
-    textEdit->setText(text +linetext); 
-    */
-        
-    textEdit->appendPlainText(">>>" + lineEdit->text());
-    QString output = console->pyRun(lineEdit->text());
-    if (output!="")
-    {
-        textEdit->appendPlainText(output);
-    }
-    lineEdit->setText("");
-    
-    if (debug)
-    {
-        qInfo() << "End of Update Console";
-    }
-}

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -3,16 +3,16 @@
 #include <QDebug>
 #include "mainwindow.h"
 //#include <python3.8/Python.h> can use this notation to chose specific versions of python if got wide imports.
-//#include "consolewidget.h"
 
 /**
  * @brief Construct a new Main Window:: Main Window object
  * 
  * @param parent 
  */
-MainWindow::MainWindow(QWidget *parent)
-    : QMainWindow(parent)
+MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) //, consoleWidget(new ConsoleWidget())
 {
+    consoleWidget = new ConsoleWidget(this);
+    //consoleWidget->show();
     console = new pyConsole(); 
     QTextEdit* textEdit = new QTextEdit(this);
     this->setCentralWidget(textEdit);
@@ -62,8 +62,11 @@ void MainWindow::createDockWindows(){
     box->setLayout(vbox);
 
     dock->setWidget(box);
-    addDockWidget(Qt::BottomDockWidgetArea, dock);
+    this->addDockWidget(Qt::BottomDockWidgetArea, dock);
 
+     dock= new QDockWidget(tr("Test"), this);    
+    dock->setWidget(consoleWidget);
+    this->addDockWidget(Qt::LeftDockWidgetArea, dock);
     //Connect Button Push to the Update Console function. 
     QObject::connect(button, &QPushButton::clicked, this, &MainWindow::updateConsole , Qt::QueuedConnection);
 }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -3,7 +3,7 @@
 
 #include <QtWidgets>
 #include "pyConsole.h" 
-
+#include "consolewidget.h"
 
 //References:
 //https://stackoverflow.com/questions/23068700/embedding-python3-in-qt-5
@@ -31,6 +31,7 @@ private:
     QLineEdit* lineEdit;
     QPlainTextEdit* textEdit;
     pyConsole* console;
+    ConsoleWidget* consoleWidget;
 };
 
 #endif //MAINWINDOW_H

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -2,7 +2,6 @@
 #define MAINWINDOW_H
 
 #include <QtWidgets>
-#include "pyConsole.h" 
 #include "consolewidget.h"
 
 //References:
@@ -21,16 +20,12 @@ public:
 
 
 private Q_SLOTS:
-    void updateConsole();
 
 private:
     void createDockWindows();
-    QDockWidget* dock;
+
     QGroupBox* box;
-    QPushButton* button;
-    QLineEdit* lineEdit;
-    QPlainTextEdit* textEdit;
-    pyConsole* console;
+    QDockWidget* dock;
     ConsoleWidget* consoleWidget;
 };
 


### PR DESCRIPTION
Move all the console functionality and object into own class. This tidies up the code and also same addition were added which Fixes #6.